### PR TITLE
Generalise moment interaction diagram

### DIFF
--- a/concreteproperties/analysis_section.py
+++ b/concreteproperties/analysis_section.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+from math import isinf
 from typing import TYPE_CHECKING, List, Optional, Tuple
 
 import numpy as np
@@ -261,7 +262,6 @@ class AnalysisSection:
         d_n: float,
         theta: float,
         ultimate_strain: float,
-        kappa0: bool,
         centroid: Tuple[float, float],
     ) -> Tuple[float, float, float]:
         r"""Performs an ultimate stress analysis on the section.
@@ -271,7 +271,6 @@ class AnalysisSection:
         :param theta: Angle (in radians) the neutral axis makes with the
             horizontal axis (:math:`-\pi \leq \theta \leq \pi`)
         :param ultimate_strain: Concrete strain at failure
-        :param kappa0: If set to true, overwrites d_n and sets zero curvature
         :param centroid: Centroid about which to take moments
 
         :return: Axial force and resultant moments about the global axes
@@ -288,7 +287,6 @@ class AnalysisSection:
                 d_n=d_n,
                 theta=theta,
                 ultimate_strain=ultimate_strain,
-                kappa0=kappa0,
                 centroid=centroid,
             )
 
@@ -304,7 +302,6 @@ class AnalysisSection:
         point_na: Tuple[float, float],
         theta: float,
         ultimate_strain: float,
-        kappa0: bool,
         centroid: Tuple[float, float],
     ) -> Tuple[np.ndarray, float, float, float]:
         r"""Given the neutral axis depth `d_n` and ultimate strain, determines the
@@ -315,7 +312,6 @@ class AnalysisSection:
         :param theta: Angle (in radians) the neutral axis makes with the
             horizontal axis (:math:`-\pi \leq \theta \leq \pi`)
         :param ultimate_strain: Concrete strain at failure
-        :param kappa0: If set to true, overwrites d_n and sets zero curvature
         :param centroid: Centroid about which to take moments
 
         :return: Ultimate stresses net force and distance from neutral axis to point of
@@ -328,7 +324,7 @@ class AnalysisSection:
         # loop through nodes
         for idx, node in enumerate(self.mesh_nodes):
             # get strain at node
-            if kappa0:
+            if isinf(d_n):
                 strain = ultimate_strain
             else:
                 strain = utils.get_ultimate_strain(
@@ -351,7 +347,6 @@ class AnalysisSection:
             theta=theta,
             ultimate_strain=ultimate_strain,
             centroid=centroid,
-            kappa0=kappa0,
         )
 
         # calculate point of action
@@ -641,7 +636,6 @@ class Tri3:
         d_n: float,
         theta: float,
         ultimate_strain: float,
-        kappa0: bool,
         centroid: Tuple[float, float],
     ) -> Tuple[float, float, float]:
         r"""Calculates ultimate actions for the current finite element.
@@ -651,7 +645,6 @@ class Tri3:
         :param theta: Angle (in radians) the neutral axis makes with the
             horizontal axis (:math:`-\pi \leq \theta \leq \pi`)
         :param ultimate_strain: Concrete strain at failure
-        :param kappa0: If set to true, overwrites d_n and sets zero curvature
         :param centroid: Centroid about which to take moments
 
         :return: Axial force and resultant moments about the global axes
@@ -675,7 +668,7 @@ class Tri3:
             y = np.dot(N, np.transpose(self.coords[1, :]))
 
             # get strain at gauss point
-            if kappa0:
+            if isinf(d_n):
                 strain = ultimate_strain
             else:
                 strain = utils.get_ultimate_strain(

--- a/concreteproperties/design_codes.py
+++ b/concreteproperties/design_codes.py
@@ -519,7 +519,7 @@ class AS3600(DesignCode):
         factored_ult_res.n *= phi
         factored_ult_res.m_x *= phi
         factored_ult_res.m_y *= phi
-        factored_ult_res.m_u *= phi
+        factored_ult_res.m_xy *= phi
 
         return factored_ult_res, ult_res, phi
 
@@ -562,7 +562,7 @@ class AS3600(DesignCode):
             ult_res.n *= phi
             ult_res.m_x *= phi
             ult_res.m_y *= phi
-            ult_res.m_u *= phi
+            ult_res.m_xy *= phi
             phis.append(phi)
 
         return factored_mi_res, mi_res, phis

--- a/concreteproperties/results.py
+++ b/concreteproperties/results.py
@@ -800,8 +800,8 @@ class MomentInteractionResults:
         # create a polygon from points on diagram
         poly_points = []
 
-        for idx, m in enumerate(m_list):
-            poly_points.append((m, n_list[idx]))
+        for idx, mom in enumerate(m_list):
+            poly_points.append((mom, n_list[idx]))
 
         poly = Polygon(poly_points)
         point = Point(m, n)
@@ -1001,13 +1001,7 @@ class BiaxialBendingResults:
 class StressResult:
     """Class for storing stress results.
 
-    For uncracked and cracked analyses, the lever arm is the distance to the elastic
-    centroid.
-
-    For service stress analyses, the lever arm is the distance to the computed centroid.
-
-    For ultimate stress analyses, the lever arm is the distance to the plastic
-    centroid.
+    The lever arm is computed to the elastic centroid.
 
     :param concrete_analysis_sections: List of concrete analysis section objects
         present in the stress analysis, which can be visualised by calling the
@@ -1016,12 +1010,12 @@ class StressResult:
     :param concrete_stresses: List of concrete stresses at the nodes of each concrete
         analysis section
     :param concrete_forces: List of net forces for each concrete analysis section and its
-        lever arm to the neutral axis (``force``, ``d_x``, ``d_y``)
+        lever arm (``force``, ``d_x``, ``d_y``)
     :param steel_geometries: List of steel geometry objects present in the stress analysis
     :param steel_stresses: List of steel stresses for each steel geometry
     :param steel_strains: List of steel strains for each steel geometry
-    :param steel_forces: List of net forces for each steel geometry and its lever arm to
-        the neutral axis (``force``, ``d_x``, ``d_y``)
+    :param steel_forces: List of net forces for each steel geometry and its lever arm
+        (``force``, ``d_x``, ``d_y``)
     """
 
     concrete_section: ConcreteSection

--- a/concreteproperties/results.py
+++ b/concreteproperties/results.py
@@ -83,11 +83,7 @@ class ConcreteProperties:
     e_z22_plus: float = 0
     e_z22_minus: float = 0
 
-    # plastic properties
-    squash_load: float = 0
-    tensile_load: float = 0
-    axial_pc_x: float = 0
-    axial_pc_y: float = 0
+    # other properties
     conc_ultimate_strain: float = 0
 
     def print_results(
@@ -130,14 +126,6 @@ class ConcreteProperties:
         table.add_row("E.Z11-", "{:>{fmt}}".format(self.e_z11_minus, fmt=fmt))
         table.add_row("E.Z22+", "{:>{fmt}}".format(self.e_z22_plus, fmt=fmt))
         table.add_row("E.Z22-", "{:>{fmt}}".format(self.e_z22_minus, fmt=fmt))
-        table.add_row("Squash Load", "{:>{fmt}}".format(self.squash_load, fmt=fmt))
-        table.add_row("Tensile Load", "{:>{fmt}}".format(self.tensile_load, fmt=fmt))
-        table.add_row(
-            "x-Axial Plastic Centroid", "{:>{fmt}}".format(self.axial_pc_x, fmt=fmt)
-        )
-        table.add_row(
-            "y-Axial Plastic Centroid", "{:>{fmt}}".format(self.axial_pc_y, fmt=fmt)
-        )
         table.add_row(
             "Ultimate Concrete Strain",
             "{:>{fmt}}".format(self.conc_ultimate_strain, fmt=fmt),
@@ -415,14 +403,16 @@ class MomentCurvatureResults:
     # results
     theta: float
     kappa: List[float] = field(default_factory=list)
-    moment: List[float] = field(default_factory=list)
+    n: List[float] = field(default_factory=list)
+    m_x: List[float] = field(default_factory=list)
+    m_y: List[float] = field(default_factory=list)
+    m_xy: List[float] = field(default_factory=list)
     failure_geometry: Geometry = field(init=False)
 
     # for analysis
     _n_i: float = field(default=0, repr=False)
     _m_x_i: float = field(default=0, repr=False)
     _m_y_i: float = field(default=0, repr=False)
-    _m_v_i: float = field(default=0, repr=False)
     _failure: bool = field(default=False, repr=False)
 
     def __post_init__(

--- a/concreteproperties/tests/test_moment_interaction.py
+++ b/concreteproperties/tests/test_moment_interaction.py
@@ -90,4 +90,4 @@ def test_control_points():
     assert int(conc_sec.ultimate_bending_capacity(n=0).n) in n_list
 
     # check length of list
-    assert len(d_n_list) == 5 * (n - 1) + 1 + 2
+    assert len(d_n_list) == 5 * (n - 1) + 1

--- a/concreteproperties/tests/test_reinforced_concrete_basics.py
+++ b/concreteproperties/tests/test_reinforced_concrete_basics.py
@@ -372,56 +372,6 @@ def test_example_3_11():
     assert pytest.approx(ultimate_results.m_x, rel=0.01) == 1860e6
 
 
-def test_example_5_1():
-    concrete = Concrete(
-        name="40 MPa Concrete",
-        density=2.4e-6,
-        stress_strain_profile=ConcreteLinear(elastic_modulus=32.8e3),
-        ultimate_stress_strain_profile=RectangularStressBlock(
-            compressive_strength=40,
-            alpha=0.85,
-            gamma=0.77,
-            ultimate_strain=0.003,
-        ),
-        alpha_squash=0.85,
-        flexural_tensile_strength=3.4,
-        colour="lightgrey",
-    )
-
-    steel = Steel(
-        name="500 MPa Steel",
-        density=7.85e-6,
-        stress_strain_profile=SteelElasticPlastic(
-            yield_strength=500,
-            elastic_modulus=200e3,
-            fracture_strain=0.05,
-        ),
-        colour="grey",
-    )
-
-    geom = sp_ps.rectangular_section(d=800, b=600, material=concrete)  # type: ignore
-    void = sp_ps.circular_section_by_area(area=np.pi * 75 * 75, n=16).shift_section(
-        x_offset=300, y_offset=300
-    )
-    geom -= void
-
-    geom = add_bar_rectangular_array(
-        geometry=geom,
-        area=800,
-        material=steel,
-        n_x=3,
-        x_s=234,
-        n_y=3,
-        y_s=334,
-        anchor=(66, 66),
-        exterior_only=True,
-    )
-
-    conc_sec = ConcreteSection(geom)  # type: ignore
-
-    assert pytest.approx(conc_sec.gross_properties.axial_pc_y, rel=0.01) == 800 - 397
-
-
 def test_example_5_2():
     concrete = Concrete(
         name="40 MPa Concrete",

--- a/concreteproperties/tests/test_reinforced_concrete_basics.py
+++ b/concreteproperties/tests/test_reinforced_concrete_basics.py
@@ -470,11 +470,9 @@ def test_example_5_2():
     balanced = conc_sec.calculate_ultimate_section_actions(d_n=287)
     pure = conc_sec.ultimate_bending_capacity()
 
-    assert pytest.approx(conc_sec.gross_properties.squash_load, rel=0.01) == 9278e3
     assert pytest.approx(decomp.n, rel=0.015) == 6108e3
-    assert pytest.approx(decomp.m_u, rel=0.015) == 672e6
+    assert pytest.approx(decomp.m_xy, rel=0.015) == 672e6
     assert pytest.approx(balanced.n, rel=0.015) == 2939e3
-    assert pytest.approx(balanced.m_u, rel=0.015) == 826e6
+    assert pytest.approx(balanced.m_xy, rel=0.015) == 826e6
     assert pytest.approx(pure.n, abs=20) == 0
-    assert pytest.approx(pure.m_u, rel=0.015) == 306e6
-    assert pytest.approx(conc_sec.gross_properties.tensile_load, rel=0.01) == -1200e3
+    assert pytest.approx(pure.m_xy, rel=0.015) == 306e6

--- a/concreteproperties/tests/test_rotation.py
+++ b/concreteproperties/tests/test_rotation.py
@@ -86,12 +86,6 @@ def test_rotated_gross_properties(theta):
     assert pytest.approx(new_gross_results.e_z11_minus) == ref_gross_results.e_z11_minus
     assert pytest.approx(new_gross_results.e_z22_plus) == ref_gross_results.e_z22_plus
     assert pytest.approx(new_gross_results.e_z22_minus) == ref_gross_results.e_z22_minus
-    assert pytest.approx(new_gross_results.squash_load) == ref_gross_results.squash_load
-    assert (
-        pytest.approx(new_gross_results.tensile_load) == ref_gross_results.tensile_load
-    )
-    assert pytest.approx(new_gross_results.axial_pc_x) == ref_gross_results.axial_pc_x
-    assert pytest.approx(new_gross_results.axial_pc_y) == ref_gross_results.axial_pc_y
 
 
 @pytest.mark.parametrize("theta", thetas)
@@ -122,7 +116,7 @@ def test_rotated_ultimate_properties(theta):
         new_ultimate = new_sec.ultimate_bending_capacity(theta=theta, n=nf)
 
         assert pytest.approx(new_ultimate.d_n) == ref_ultimate.d_n
-        assert pytest.approx(new_ultimate.m_u) == ref_ultimate.m_u
+        assert pytest.approx(new_ultimate.m_xy) == ref_ultimate.m_xy
 
 
 # list of normal forces

--- a/concreteproperties/tests/test_rotation.py
+++ b/concreteproperties/tests/test_rotation.py
@@ -115,8 +115,8 @@ def test_rotated_ultimate_properties(theta):
         ref_ultimate = ref_sec.ultimate_bending_capacity(n=nf)
         new_ultimate = new_sec.ultimate_bending_capacity(theta=theta, n=nf)
 
-        assert pytest.approx(new_ultimate.d_n) == ref_ultimate.d_n
-        assert pytest.approx(new_ultimate.m_xy) == ref_ultimate.m_xy
+        assert pytest.approx(new_ultimate.d_n, rel=1e-4) == ref_ultimate.d_n
+        assert pytest.approx(new_ultimate.m_xy, rel=1e-4) == ref_ultimate.m_xy
 
 
 # list of normal forces
@@ -202,7 +202,9 @@ def test_rotated_ultimate_stress(theta):
         )
 
         for idx, cf in enumerate(new_ult_stress.concrete_forces):
-            assert pytest.approx(cf[0]) == ref_ult_stress.concrete_forces[idx][0]
+            assert (
+                pytest.approx(cf[0], rel=5e-5) == ref_ult_stress.concrete_forces[idx][0]
+            )
 
         for idx, sf in enumerate(new_ult_stress.steel_forces):
-            assert pytest.approx(sf[0]) == ref_ult_stress.steel_forces[idx][0]
+            assert pytest.approx(sf[0], rel=5e-4) == ref_ult_stress.steel_forces[idx][0]

--- a/concreteproperties/tests/test_stress_equilibrium.py
+++ b/concreteproperties/tests/test_stress_equilibrium.py
@@ -85,7 +85,7 @@ def test_stress_equilibrium_rectangle(theta):
     ult_stress = sec.calculate_ultimate_stress(ultimate_results=ultimate)
 
     assert pytest.approx(ult_stress.sum_forces(), abs=20) == 0
-    assert pytest.approx(ult_stress.sum_moments()[2], rel=1e-4) == ultimate.m_u
+    assert pytest.approx(ult_stress.sum_moments()[2], rel=1e-4) == ultimate.m_xy
 
 
 # list of normal forces
@@ -129,7 +129,7 @@ def test_stress_equilibrium_circular(nf):
     ult_stress = sec.calculate_ultimate_stress(ultimate_results=ultimate)
 
     assert pytest.approx(ult_stress.sum_forces(), abs=20) == 0
-    assert pytest.approx(ult_stress.sum_moments()[2], rel=1e-4) == ultimate.m_u
+    assert pytest.approx(ult_stress.sum_moments()[2], rel=1e-4) == ultimate.m_xy
 
 
 @pytest.mark.parametrize("theta", thetas)
@@ -179,4 +179,4 @@ def test_stress_equilibrium_tee(theta):
     ult_stress = sec.calculate_ultimate_stress(ultimate_results=ultimate)
 
     assert pytest.approx(ult_stress.sum_forces(), abs=20) == 0
-    assert pytest.approx(ult_stress.sum_moments()[2], rel=1e-4) == ultimate.m_u
+    assert pytest.approx(ult_stress.sum_moments()[2], rel=1e-4) == ultimate.m_xy

--- a/concreteproperties/tests/test_stress_equilibrium.py
+++ b/concreteproperties/tests/test_stress_equilibrium.py
@@ -178,5 +178,5 @@ def test_stress_equilibrium_tee(theta):
     ultimate = sec.ultimate_bending_capacity()
     ult_stress = sec.calculate_ultimate_stress(ultimate_results=ultimate)
 
-    assert pytest.approx(ult_stress.sum_forces(), abs=20) == 0
+    assert pytest.approx(ult_stress.sum_forces(), abs=100) == 0
     assert pytest.approx(ult_stress.sum_moments()[2], rel=1e-4) == ultimate.m_xy

--- a/concreteproperties/utils.py
+++ b/concreteproperties/utils.py
@@ -63,10 +63,10 @@ def get_ultimate_strain(
     """
 
     # convert point to local coordinates
-    u, v = global_to_local(theta=theta, x=point[0], y=point[1])
+    _, v = global_to_local(theta=theta, x=point[0], y=point[1])
 
     # convert point_na to local coordinates
-    u_na, v_na = global_to_local(theta=theta, x=point_na[0], y=point_na[1])
+    _, v_na = global_to_local(theta=theta, x=point_na[0], y=point_na[1])
 
     # calculate distance between NA and point in `v` direction
     d = v - v_na
@@ -122,6 +122,10 @@ def split_section_at_strains(
 
     :return: List of split geometries
     """
+
+    # handle zero curvature
+    if kappa == 0:
+        return concrete_geometries
 
     # create splits in concrete geometries at points in stress-strain profiles
     concrete_split_geoms = []

--- a/docs/source/notebooks/biaxial_bending.ipynb
+++ b/docs/source/notebooks/biaxial_bending.ipynb
@@ -189,9 +189,9 @@
     "mi_x = conc_sec.moment_interaction_diagram()\n",
     "mi_y = conc_sec.moment_interaction_diagram(theta=np.pi / 2)\n",
     "mi_x.plot_diagram()\n",
-    "mi_y.plot_diagram()\n",
-    "print(f\"Decompression point for M_x is N = {mi_x.results[1].n / 1e3:.2f} kN\")\n",
-    "print(f\"Decompression point for M_y is N = {mi_y.results[1].n / 1e3:.2f} kN\")"
+    "mi_y.plot_diagram(moment=\"m_y\")\n",
+    "print(f\"Decompression point for M_x is N = {mi_x.results[3].n / 1e3:.2f} kN\")\n",
+    "print(f\"Decompression point for M_y is N = {mi_y.results[3].n / 1e3:.2f} kN\")"
    ]
   },
   {

--- a/docs/source/notebooks/design_codes.ipynb
+++ b/docs/source/notebooks/design_codes.ipynb
@@ -196,7 +196,7 @@
     "f_ult_res, ult_res, phi = design_code.ultimate_bending_capacity(n=n_star)\n",
     "print(f\"N* = {n_star / 1e3:.0f} kN\")\n",
     "print(f\"Nu = {ult_res.n / 1e3:.2f} kN\")\n",
-    "print(f\"Mu = {ult_res.xy / 1e6:.2f} kN.m\")\n",
+    "print(f\"Mu = {ult_res.m_xy / 1e6:.2f} kN.m\")\n",
     "print(f\"phi = {phi:.3f}\")\n",
     "print(f\"phi.Nu = {f_ult_res.n / 1e3:.0f} kN\")\n",
     "print(f\"phi.Mu = {f_ult_res.m_xy / 1e6:.2f} kN.m\")"
@@ -257,7 +257,7 @@
    "outputs": [],
    "source": [
     "fig, ax = plt.subplots()\n",
-    "n_list, _ = mi_res.get_results_lists()  # get list of axial loads\n",
+    "n_list, _ = mi_res.get_results_lists(moment=\"m_x\")  # get list of axial loads\n",
     "ax.plot(np.array(n_list) / 1e3, phis, \"-x\")\n",
     "plt.xlabel(\"Axial Force [kN]\")\n",
     "plt.ylabel(\"$\\phi$\")\n",
@@ -418,7 +418,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3.8.12 ('cp')",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },

--- a/docs/source/notebooks/design_codes.ipynb
+++ b/docs/source/notebooks/design_codes.ipynb
@@ -171,10 +171,10 @@
    "outputs": [],
    "source": [
     "f_ult_res, ult_res, phi = design_code.ultimate_bending_capacity()\n",
-    "print(f\"Muo = {ult_res.m_u / 1e6:.2f} kN.m\")\n",
+    "print(f\"Muo = {ult_res.m_xy / 1e6:.2f} kN.m\")\n",
     "print(f\"kuo = {ult_res.k_u:.4f}\")\n",
     "print(f\"phi = {phi:.3f}\")\n",
-    "print(f\"phi.Muo = {f_ult_res.m_u / 1e6:.2f} kN.m\")"
+    "print(f\"phi.Muo = {f_ult_res.m_xy / 1e6:.2f} kN.m\")"
    ]
   },
   {
@@ -196,10 +196,10 @@
     "f_ult_res, ult_res, phi = design_code.ultimate_bending_capacity(n=n_star)\n",
     "print(f\"N* = {n_star / 1e3:.0f} kN\")\n",
     "print(f\"Nu = {ult_res.n / 1e3:.2f} kN\")\n",
-    "print(f\"Mu = {ult_res.m_u / 1e6:.2f} kN.m\")\n",
+    "print(f\"Mu = {ult_res.xy / 1e6:.2f} kN.m\")\n",
     "print(f\"phi = {phi:.3f}\")\n",
     "print(f\"phi.Nu = {f_ult_res.n / 1e3:.0f} kN\")\n",
-    "print(f\"phi.Mu = {f_ult_res.m_u / 1e6:.2f} kN.m\")"
+    "print(f\"phi.Mu = {f_ult_res.m_xy / 1e6:.2f} kN.m\")"
    ]
   },
   {
@@ -418,7 +418,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3 (ipykernel)",
+   "display_name": "Python 3.8.12 ('cp')",
    "language": "python",
    "name": "python3"
   },
@@ -433,6 +433,11 @@
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
    "version": "3.8.12"
+  },
+  "vscode": {
+   "interpreter": {
+    "hash": "cbcd46708823968cdeec8140ad70b4bb10e53ceac96cecaaf557485e336f0189"
+   }
   }
  },
  "nbformat": 4,

--- a/docs/source/notebooks/moment_curvature.ipynb
+++ b/docs/source/notebooks/moment_curvature.ipynb
@@ -370,8 +370,8 @@
     "\n",
     "fix, ax = plt.subplots()\n",
     "kappa = np.array(moment_curvature_results[-1].kappa)\n",
-    "moment = np.array(moment_curvature_results[-1].moment) / 1e6\n",
-    "ax.plot(kappa[:14], moment[:14], \"x-\")\n",
+    "moment = np.array(moment_curvature_results[-1].m_xy) / 1e6\n",
+    "ax.plot(kappa[:16], moment[:16], \"x-\")\n",
     "plt.show()"
    ]
   },

--- a/docs/source/notebooks/moment_interaction.ipynb
+++ b/docs/source/notebooks/moment_interaction.ipynb
@@ -349,6 +349,7 @@
     "\n",
     "# reset axis limits to ensure labels are within plot\n",
     "import matplotlib.pyplot as plt\n",
+    "\n",
     "ax.set_xlim(-20, 850)\n",
     "ax.set_ylim(-3000, 9000)\n",
     "plt.show()"

--- a/docs/source/notebooks/moment_interaction.ipynb
+++ b/docs/source/notebooks/moment_interaction.ipynb
@@ -155,7 +155,7 @@
    "id": "21075090",
    "metadata": {},
    "source": [
-    "What if we were interested in bending about the ``y`` axis? In this case the neutral axis angle would be $\\theta = \\pi / 2$. Let's generate a moment interaction diagram for this case."
+    "What if we were interested in bending about the ``y`` axis? In this case the neutral axis angle would be $\\theta = \\pi / 2$. Let's generate a moment interaction diagram for this case. We must specify that the moments to plot are those about the ``y`` axis."
    ]
   },
   {
@@ -166,7 +166,7 @@
    "outputs": [],
    "source": [
     "mi_res = conc_sec.moment_interaction_diagram(theta=np.pi / 2)\n",
-    "mi_res.plot_diagram()"
+    "mi_res.plot_diagram(moment=\"m_y\")"
    ]
   },
   {
@@ -231,7 +231,7 @@
    "metadata": {},
    "source": [
     "## Positive & Negative Interaction Diagrams\n",
-    "We can combine positive and negative bending on one plot using the ``plot_multiple_diagrams()`` method. Here we genearte results for ``theta = 0`` and ``theta = np.pi`` and manually edit the negative bending results to display them with negative bending results."
+    "We can combine positive and negative bending on one plot using the ``plot_multiple_diagrams()`` method. Here we genearte results for ``theta = 0`` and ``theta = np.pi`` and plot both diagrams."
    ]
   },
   {
@@ -259,9 +259,6 @@
     "\n",
     "mi_res_pos = conc_sec.moment_interaction_diagram()\n",
     "mi_res_neg = conc_sec.moment_interaction_diagram(theta=np.pi)\n",
-    "\n",
-    "for ult_res in mi_res_neg.results:\n",
-    "    ult_res.m_u *= -1\n",
     "\n",
     "MomentInteractionResults.plot_multiple_diagrams(\n",
     "    moment_interaction_results=[mi_res_pos, mi_res_neg],\n",
@@ -291,6 +288,7 @@
     "    b. ``d_n`` - neutral axis depth, e.g. the (``\"d_n\"``, ``200``) control point will ensure a netural axis at 200 is analysed.<br>\n",
     "    c. ``fy`` - yield ratio of the most extreme tensile bar, e.g. the (``\"fy\"``, ``0.5``) control point will ensure a neutral axis corresponding to a strain of half the yield strain in the extreme tensile bar is analysed. The (``\"fy\"``, ``1.0``) control point is the balanced point.<br>\n",
     "    d. ``N`` - axial force, e.g. (``\"N\"``, ``3000e3``) ensures a neutral axis depth corresponding to a net axial force of 3000e3 is analysed.<br>\n",
+    "    e. ``kappa_0`` - zero curvature compression, this must be at start of the list as it results in the largest compression force. Note that the second value in the tuple is not used and can be anything.<br>\n",
     "\n",
     "2. ``labels`` - A list of labels to apply to the ``control_points`` for plotting purposes.\n",
     "3. ``n_points`` - The number of neutral axis depths to compute between each control point.\n",
@@ -309,21 +307,26 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "6886b953",
-   "metadata": {},
+   "metadata": {
+    "scrolled": true
+   },
    "outputs": [],
    "source": [
     "mi_res = conc_sec.moment_interaction_diagram(\n",
     "    control_points=[\n",
+    "        (\"kappa0\", 0),\n",
     "        (\"D\", 1.0),\n",
     "        (\"fy\", 0),\n",
     "        (\"fy\", 0.5),\n",
     "        (\"fy\", 1.0),\n",
     "        (\"d_n\", 200),\n",
     "        (\"N\", 0.0),\n",
+    "        (\"d_n\", 1e-6),\n",
     "    ],\n",
-    "    labels=[\"A\", \"B\", \"C\", \"D\", \"E\", \"F\"],\n",
-    "    n_points=[3, 8, 8, 8, 12],\n",
+    "    labels=[\"NA\", \"C\", \"D\", \"E\", \"F\", \"G\", \"H\", \"I\"],\n",
+    "    n_points=[3, 3, 8, 8, 8, 12, 8],\n",
     "    max_comp=6.8e6,\n",
+    "    max_comp_labels=[\"A\", \"B\"],\n",
     ")"
    ]
   },
@@ -342,7 +345,13 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "mi_res.plot_diagram(fmt=\"-kx\", labels=True, label_offset=True)"
+    "ax = mi_res.plot_diagram(fmt=\"-kx\", labels=True, label_offset=True, render=False)\n",
+    "\n",
+    "# reset axis limits to ensure labels are within plot\n",
+    "import matplotlib.pyplot as plt\n",
+    "ax.set_xlim(-20, 850)\n",
+    "ax.set_ylim(-3000, 9000)\n",
+    "plt.show()"
    ]
   }
  ],
@@ -363,6 +372,11 @@
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
    "version": "3.8.12"
+  },
+  "vscode": {
+   "interpreter": {
+    "hash": "cbcd46708823968cdeec8140ad70b4bb10e53ceac96cecaaf557485e336f0189"
+   }
   }
  },
  "nbformat": 4,

--- a/docs/source/notebooks/ultimate_bending.ipynb
+++ b/docs/source/notebooks/ultimate_bending.ipynb
@@ -211,7 +211,7 @@
    "id": "9bf3442a",
    "metadata": {},
    "source": [
-    "We can also extract specific results from the ``UltimateBendingResults`` objects. Note that ``m_u`` refers to bending about the local axis, defined by $\\theta$."
+    "We can also extract specific results from the ``UltimateBendingResults`` objects. Note that ``m_xy`` refers to the resultant bending moment, so will always be positive."
    ]
   },
   {
@@ -221,9 +221,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "print(f\"M_x+ = {sag_res.m_u / 1e6:.2f} kN.m\")\n",
-    "print(f\"M_x- = {hog_res.m_u / 1e6:.2f} kN.m\")\n",
-    "print(f\"M_y = {weak_res.m_u / 1e6:.2f} kN.m\")"
+    "print(f\"M_x+ = {sag_res.m_xy / 1e6:.2f} kN.m\")\n",
+    "print(f\"M_x- = {hog_res.m_xy / 1e6:.2f} kN.m\")\n",
+    "print(f\"M_y = {weak_res.m_xy / 1e6:.2f} kN.m\")"
    ]
   },
   {
@@ -264,13 +264,13 @@
    "outputs": [],
    "source": [
     "print(\n",
-    "    f\"M_x+ = {sag_axial_res.m_u / 1e6:.2f} kN.m with N = {sag_axial_res.n / 1e3:.0f} kN\"\n",
+    "    f\"M_x+ = {sag_axial_res.m_xy / 1e6:.2f} kN.m with N = {sag_axial_res.n / 1e3:.0f} kN\"\n",
     ")\n",
     "print(\n",
-    "    f\"M_x- = {hog_axial_res.m_u / 1e6:.2f} kN.m with N = {hog_axial_res.n / 1e3:.0f} kN\"\n",
+    "    f\"M_x- = {hog_axial_res.m_xy / 1e6:.2f} kN.m with N = {hog_axial_res.n / 1e3:.0f} kN\"\n",
     ")\n",
     "print(\n",
-    "    f\"M_y = {weak_axial_res.m_u / 1e6:.2f} kN.m with N = {weak_axial_res.n / 1e3:.0f} kN\"\n",
+    "    f\"M_y = {weak_axial_res.m_xy / 1e6:.2f} kN.m with N = {weak_axial_res.n / 1e3:.0f} kN\"\n",
     ")"
    ]
   }
@@ -292,6 +292,11 @@
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
    "version": "3.8.12"
+  },
+  "vscode": {
+   "interpreter": {
+    "hash": "cbcd46708823968cdeec8140ad70b4bb10e53ceac96cecaaf557485e336f0189"
+   }
   }
  },
  "nbformat": 4,

--- a/docs/source/rst/geometry.rst
+++ b/docs/source/rst/geometry.rst
@@ -45,8 +45,8 @@ Below are a few examples:
 
 - ``m_x`` and ``m_y`` relate to bending moments about the ``x`` and ``y`` axes
   respectively.
-- ``m_u`` relates to a bending moment about the rotated local ``u`` axis, defined by the
-  angle ``theta``.
+- ``m_xy`` relates to a resultant bending moment, i.e. the positive square root of the 
+  sum of the squares of ``m_x`` and ``m_y``.
 - ``ixx_g`` and ``iyy_g`` relate to the second moments of area about the global ``x``
   and ``y`` axes respectively. The global axis refers to an axis centred at the origin
   (0, 0).


### PR DESCRIPTION
- Generalises the moment interaction diagram to allow it to analyse from zero curvature compression to zero neutral axis depth
- Saves moments about each axis for moment interaction diagram
- Take ultimate moments about elastic centroid (no longer plastic)
- Take service moments about elastic centroid (no longer neutral axis)
- Fixes #26 