### PR TITLE
fix unintended error when MC analysis reaches end

### DIFF
--- a/concreteproperties/concrete_section.py
+++ b/concreteproperties/concrete_section.py
@@ -576,7 +576,8 @@ class ConcreteSection:
                         disp=False,
                     )
                 except ValueError:
-                    warnings.warn("brentq algorithm failed.")
+                    if not moment_curvature._failure:
+                        warnings.warn("brentq algorithm failed.")
 
                 m_xy = np.sqrt(
                     moment_curvature._m_x_i**2 + moment_curvature._m_y_i**2


### PR DESCRIPTION
@robbievanleeuwen, this pull request addresses the `brentq algorithm fails.` message occurring when the intended behaviour at the end of a moment curvature analysis is that the `brentq` fails intentionally due to the concrete or steel strains being exceeded and the `_failure` flag being set by `service_normal_force_convergence()` method.

Will now only raise the warning if the `service_normal_force_convergence()` method has not set the `_failure` flag to True.