### PR TITLE
Calculate moments about gross centroid

### DIFF
--- a/concreteproperties/concrete_section.py
+++ b/concreteproperties/concrete_section.py
@@ -28,11 +28,20 @@ class ConcreteSection:
     def __init__(
         self,
         geometry: sp_geom.CompoundGeometry,
+        moment_centroid: Optional[Tuple[float, float]] = None,
+        geometric_centroid_override: bool = False,
     ):
         """Inits the ConcreteSection class.
 
         :param geometry: *sectionproperties* CompoundGeometry object describing the
             reinforced concrete section
+        :param moment_centroid: If specified, all moments for service and ultimate
+            analyses are calculated about this point. If not specified, all moments are
+            calculated about the gross cross-section centroid, i.e. no material
+            properties applied.
+        :param geometric_centroid_override: If set to True, sets ``moment_centroid`` to
+            the geometric centroid i.e. material properties applied (useful for
+            composite section analysis)
         """
 
         self.compound_geometry = geometry
@@ -75,6 +84,19 @@ class ConcreteSection:
         # calculate gross area properties
         self.calculate_gross_area_properties()
 
+        # set moment centroid
+        if moment_centroid:
+            self.moment_centroid = moment_centroid
+        else:
+            self.moment_centroid = (
+                self.gross_properties.cx_gross,
+                self.gross_properties.cy_gross,
+            )
+
+        # if moment centroid overriden
+        if geometric_centroid_override:
+            self.moment_centroid = self.gross_properties.cx, self.gross_properties.cy
+
     def calculate_gross_area_properties(
         self,
     ):
@@ -95,6 +117,8 @@ class ConcreteSection:
             self.gross_properties.e_qy += (
                 area * geom.material.elastic_modulus * centroid[0]
             )
+            self.gross_properties.qx_gross += area * centroid[1]
+            self.gross_properties.qy_gross += area * centroid[0]
 
         # sum concrete areas
         for conc_geom in self.concrete_geometries:
@@ -117,6 +141,12 @@ class ConcreteSection:
         )
         self.gross_properties.cy = (
             self.gross_properties.e_qx / self.gross_properties.e_a
+        )
+        self.gross_properties.cx_gross = (
+            self.gross_properties.qy_gross / self.gross_properties.total_area
+        )
+        self.gross_properties.cy_gross = (
+            self.gross_properties.qx_gross / self.gross_properties.total_area
         )
 
         # global second moments of area
@@ -738,7 +768,7 @@ class ConcreteSection:
                 point_na=point_na,
                 theta=moment_curvature.theta,
                 kappa=kappa,
-                centroid=(self.gross_properties.cx, self.gross_properties.cy),
+                centroid=self.moment_centroid,
             )
 
             n += n_sec
@@ -810,8 +840,8 @@ class ConcreteSection:
             n += force
 
             # calculate moment
-            m_x += force * (centroid[1] - self.gross_properties.cy)
-            m_y += force * (centroid[0] - self.gross_properties.cx)
+            m_x += force * (centroid[1] - self.moment_centroid[1])
+            m_y += force * (centroid[0] - self.moment_centroid[0])
 
         moment_curvature._kappa = kappa
         moment_curvature._n_i = n
@@ -966,7 +996,7 @@ class ConcreteSection:
                 d_n=d_n,
                 theta=ultimate_results.theta,
                 ultimate_strain=self.gross_properties.conc_ultimate_strain,
-                centroid=(self.gross_properties.cx, self.gross_properties.cy),
+                centroid=self.moment_centroid,
             )
 
             n += n_sec
@@ -1004,8 +1034,8 @@ class ConcreteSection:
             )
 
             # calculate moment
-            m_x += force * (centroid[1] - self.gross_properties.cy)
-            m_y += force * (centroid[0] - self.gross_properties.cx)
+            m_x += force * (centroid[1] - self.moment_centroid[1])
+            m_y += force * (centroid[0] - self.moment_centroid[0])
 
             # calculate k_u
             d = ef_v - c_v
@@ -1724,7 +1754,7 @@ class ConcreteSection:
                 kappa=kappa,
                 point_na=point_na,
                 theta=theta,
-                centroid=(self.gross_properties.cx, self.gross_properties.cy),
+                centroid=self.moment_centroid,
             )
 
             # save results
@@ -1759,8 +1789,8 @@ class ConcreteSection:
             lumped_reinf_forces.append(
                 (
                     n_lumped,
-                    centroid[0] - self.gross_properties.cx,
-                    centroid[1] - self.gross_properties.cy,
+                    centroid[0] - self.moment_centroid[0],
+                    centroid[1] - self.moment_centroid[1],
                 )
             )
             lumped_reinf_geoms.append(lumped_geom)
@@ -1845,7 +1875,7 @@ class ConcreteSection:
                 point_na=point_na,
                 theta=ultimate_results.theta,
                 ultimate_strain=self.gross_properties.conc_ultimate_strain,
-                centroid=(self.gross_properties.cx, self.gross_properties.cy),
+                centroid=self.moment_centroid,
             )
 
             # save results
@@ -1884,8 +1914,8 @@ class ConcreteSection:
             lumped_reinf_forces.append(
                 (
                     n_lumped,
-                    centroid[0] - self.gross_properties.cx,
-                    centroid[1] - self.gross_properties.cy,
+                    centroid[0] - self.moment_centroid[0],
+                    centroid[1] - self.moment_centroid[1],
                 )
             )
             lumped_reinf_geoms.append(lumped_geom)

--- a/concreteproperties/results.py
+++ b/concreteproperties/results.py
@@ -55,10 +55,14 @@ class GrossProperties:
     # first moments of area
     e_qx: float = 0
     e_qy: float = 0
+    qx_gross: float = 0
+    qy_gross: float = 0
 
     # centroids
     cx: float = 0
     cy: float = 0
+    cx_gross: float = 0
+    cy_gross: float = 0
 
     # second moments of area
     e_ixx_g: float = 0
@@ -116,6 +120,8 @@ class GrossProperties:
         table.add_row("E.Qy", "{:>{fmt}}".format(self.e_qy, fmt=fmt))
         table.add_row("x-Centroid", "{:>{fmt}}".format(self.cx, fmt=fmt))
         table.add_row("y-Centroid", "{:>{fmt}}".format(self.cy, fmt=fmt))
+        table.add_row("x-Centroid (Gross)", "{:>{fmt}}".format(self.cx_gross, fmt=fmt))
+        table.add_row("y-Centroid (Gross)", "{:>{fmt}}".format(self.cy_gross, fmt=fmt))
         table.add_row("E.Ixx_g", "{:>{fmt}}".format(self.e_ixx_g, fmt=fmt))
         table.add_row("E.Iyy_g", "{:>{fmt}}".format(self.e_iyy_g, fmt=fmt))
         table.add_row("E.Ixy_g", "{:>{fmt}}".format(self.e_ixy_g, fmt=fmt))

--- a/docs/source/notebooks/composite_section.ipynb
+++ b/docs/source/notebooks/composite_section.ipynb
@@ -600,8 +600,12 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "print(f\"cx_geom = {conc_sec.moment_centroid[0]:.2f}; cy_geom = {conc_sec.moment_centroid[1]:.2f}\")\n",
-    "print(f\"cx_gross = {conc_sec.gross_properties.cx_gross:.2f}; cy_gross = {conc_sec.gross_properties.cy_gross:.2f}\")"
+    "print(\n",
+    "    f\"cx_geom = {conc_sec.moment_centroid[0]:.2f}; cy_geom = {conc_sec.moment_centroid[1]:.2f}\"\n",
+    ")\n",
+    "print(\n",
+    "    f\"cx_gross = {conc_sec.gross_properties.cx_gross:.2f}; cy_gross = {conc_sec.gross_properties.cy_gross:.2f}\"\n",
+    ")"
    ]
   },
   {

--- a/docs/source/notebooks/composite_section.ipynb
+++ b/docs/source/notebooks/composite_section.ipynb
@@ -542,7 +542,7 @@
    "id": "112ad018",
    "metadata": {},
    "source": [
-    "Next we construct the composite geometry."
+    "Next we construct the composite geometry. Note that we set ``geometric_centroid_override=True`` to ensure that moments are calculated about the geometric centroid rather than the gross centroid. In previous examples the geometry was symmetric so setting this made no difference to the results."
    ]
   },
   {
@@ -581,8 +581,27 @@
     "geom = geom.rotate_section(angle=np.pi / 2, use_radians=True)\n",
     "\n",
     "# create concrete section and plot\n",
-    "conc_sec = ConcreteSection(geom)\n",
+    "conc_sec = ConcreteSection(geom, geometric_centroid_override=True)\n",
     "conc_sec.plot_section()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "326d0fe9",
+   "metadata": {},
+   "source": [
+    "We can compare the gross and geometric centroids. The geometric centroid takes into account the difference elastic moduli of each material, whereas the gross centroid does not."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "d5879722",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(f\"cx_geom = {conc_sec.moment_centroid[0]:.2f}; cy_geom = {conc_sec.moment_centroid[1]:.2f}\")\n",
+    "print(f\"cx_gross = {conc_sec.gross_properties.cx_gross:.2f}; cy_gross = {conc_sec.gross_properties.cy_gross:.2f}\")"
    ]
   },
   {

--- a/docs/source/user_guide/analysis.rst
+++ b/docs/source/user_guide/analysis.rst
@@ -173,6 +173,11 @@ method.
 ..  automethod:: concreteproperties.concrete_section.ConcreteSection.calculate_uncracked_stress
   :noindex:
 
+.. note::
+  Forces/moments are assumed to be acting at the geometric centroid, i.e. ``cx`` and
+  ``cy`` in
+  :meth:`~concreteproperties.concrete_section.ConcreteSection.get_gross_properties`
+
 
 Cracked Stress
 ^^^^^^^^^^^^^^
@@ -188,6 +193,11 @@ method and these results passed to
 
 ..  automethod:: concreteproperties.concrete_section.ConcreteSection.calculate_cracked_stress
   :noindex:
+
+.. note::
+  Forces/moments are assumed to be acting at the geometric centroid, i.e. ``cx`` and
+  ``cy`` in
+  :meth:`~concreteproperties.concrete_section.ConcreteSection.get_gross_properties`
 
 
 Service Stress
@@ -206,6 +216,11 @@ method and these results passed to
 ..  automethod:: concreteproperties.concrete_section.ConcreteSection.calculate_service_stress
   :noindex:
 
+.. note::
+  Forces/moments are assumed to be acting at the gross centroid, i.e. ``cx_gross`` and
+  ``cy_gross`` in
+  :meth:`~concreteproperties.concrete_section.ConcreteSection.get_gross_properties`
+
 
 Ultimate Stress
 ^^^^^^^^^^^^^^^
@@ -222,3 +237,8 @@ method and these results passed to
 
 ..  automethod:: concreteproperties.concrete_section.ConcreteSection.calculate_ultimate_stress
   :noindex:
+
+.. note::
+  Forces/moments are assumed to be acting at the gross centroid, i.e. ``cx_gross`` and
+  ``cy_gross`` in
+  :meth:`~concreteproperties.concrete_section.ConcreteSection.get_gross_properties`

--- a/docs/source/user_guide/assumptions.rst
+++ b/docs/source/user_guide/assumptions.rst
@@ -16,6 +16,13 @@ General
 * Stresses in materials are determined from strains by linear interpolation from the
   corresponding stress-strain profile (linear extrapolation is used where the strains
   are outside the range of the profile)
+* All moments in service and ultimate analyses (moment-curvature, ultimate bending,
+  moment interaction, biaxial bending, service stress, ultimate stress) are calculated
+  about, or assumed to be about the gross centroid (no material properties applied),
+  unless otherwise specified in the intitialisation of
+  :class:`~concreteproperties.concrete_section.ConcreteSection`
+* Moment inputs for elastic stress analysis (cracked and uncracked), are assumed to be
+  taken to be about the geometric centroid (material properties applied)
 * Finite element assumptions and background can be found 
   `here <https://sectionproperties.readthedocs.io/en/latest/rst/theory.html>`_
 
@@ -34,7 +41,8 @@ Ultimate Analysis
   reaching its ultimate strength
 * The stress-strain relationship for concrete may be assumed to be rectangular,
   trapezoidal, bilinear, parabolic, or any other arbitrary shape that results in the
-  prediction of strength in substantial agreement with the results of comprehensive tests
+  prediction of strength in substantial agreement with the results of comprehensive
+  tests
 
 Conventions
 -----------


### PR DESCRIPTION
Fixes #53.

Introduces ``moment_centroid`` and ``geometric_centroid_override`` to the ``ConcreteSection.__init__()`` method.

Where ``moment_centroid`` is now used to calculate moments:
- Moment curvature analysis
- Ultimate bending capacity
- Moment interaction diagram
- Biaxial bending diagram

Where user supplied moments are now assumed to be taken about ``moment_centroid``:
- Service stress analysis
- Ultimate stress analysis

Where the geometric centroid (takes into account differing material properties) is still used in analysis:
- Cracked area properties
- Uncracked stress analysis
- Cracked stress analysis

These three had to remain as is because the way elastic stress is calculated uses the area properties calculated using the reinforcement.

The above assumptions (have hopefully) been made clear in the documentation.

@Agent6-6-6 let me know if you have any comments with this one!