### PR TITLE
Update EC2 parabolic stress-strain profile

### DIFF
--- a/docs/source/_static/doc_plots/ec2_parabolic_ultimate_plot.py
+++ b/docs/source/_static/doc_plots/ec2_parabolic_ultimate_plot.py
@@ -1,0 +1,188 @@
+import matplotlib.pyplot as plt
+import concreteproperties.stress_strain_profile as ssp
+
+
+def ec2_parabolic_ultimate_plot(render=False):
+    """Creates a plot for use in the docstring of EurocodeParabolicUltimate class,
+    generates a plot with stress-strain parameters shown to aid in
+    interpreting class variables.
+
+    :param render: Set to True to plot for testing purposes, note will plot
+        automatically in a docstring plot directive when set to default of False
+    """
+    # create EurocodeParabolicUltimate stress-strain profile
+    compressive_strength = 40
+    alpha_cc = 1.0
+    gamma_c = 1.5
+    f_ck = compressive_strength
+    f_cd = alpha_cc * f_ck / gamma_c
+    n_points = 50
+
+    stress_strain_profile = ssp.EurocodeParabolicUltimate(
+        compressive_strength=f_ck,
+        alpha_cc=alpha_cc,
+        gamma_c=gamma_c,
+        n_points=n_points,
+    )
+
+    stress_strain_profile_nominal = ssp.EurocodeParabolicUltimate(
+        compressive_strength=f_ck,
+        alpha_cc=1,
+        gamma_c=1,
+        n_points=n_points,
+    )
+    # overide default tension branch strain
+    stress_strain_profile.strains[0] = 0
+
+    # add return of stress-strain diagram to zero stress
+    stress_strain_profile.stresses.append(0)
+    stress_strain_profile.strains.append(stress_strain_profile.strains[-1])
+
+    # overide default tension branch strain
+    stress_strain_profile_nominal.strains[0] = 0
+
+    # add return of stress-strain diagram to f_cd
+    stress_strain_profile_nominal.stresses.append(stress_strain_profile.stresses[-2])
+    stress_strain_profile_nominal.strains.append(stress_strain_profile.strains[-1])
+
+    # plot design stress-strain relationship
+    ax = stress_strain_profile.plot_stress_strain(
+        fmt="-k", render=False, linewidth=1, figsize=(8, 6)
+    )
+
+    # plot nominal stress-strian relationship
+    ax.plot(
+        stress_strain_profile_nominal.strains,
+        stress_strain_profile_nominal.stresses,
+        color="k",
+        lw=1.25,
+        ls="--",
+        dashes=[12, 6],
+    )
+
+    # add fake origin axes lines
+    plt.axvline(linewidth=1.5, color="grey")
+    plt.axhline(linewidth=1.5, color="grey")
+
+    # add arrows at end of origin axes
+    ax.plot(
+        (1),
+        (0),
+        ls="",
+        marker=">",
+        ms=10,
+        color="k",
+        transform=ax.get_yaxis_transform(),
+        clip_on=False,
+    )
+    ax.plot(
+        (0),
+        (1),
+        ls="",
+        marker="^",
+        ms=10,
+        color="k",
+        transform=ax.get_xaxis_transform(),
+        clip_on=False,
+    )
+
+    # add title and axes labels
+    plt.title(label="Eurocode 2 Parabolic Stress-Strain Profile").set_fontsize(16)
+    plt.xlabel("Compressive Strain $\\varepsilon_c$", labelpad=10).set_fontsize(16)
+    plt.ylabel("Compressive Stress $\sigma_c$", labelpad=10).set_fontsize(16)
+
+    # define data for annotations
+    f_cd = max(stress_strain_profile.stresses)
+    eps_c2, eps_cu2 = stress_strain_profile.epsilon_parabolic(f_ck=f_ck)
+    x = [
+        0,
+        eps_c2,
+        eps_cu2,
+        eps_c2,
+        eps_cu2,
+    ]
+    y = [
+        0,
+        f_cd,
+        f_cd,
+        f_ck,
+        f_ck,
+    ]
+    x_annotation = [
+        "$0$",
+        "",
+        "",
+        "$\\varepsilon_{c2}$",
+        "$\\varepsilon_{cu2}$",
+    ]
+    y_label = [
+        0,
+        f_cd,
+        f_ck,
+    ]
+    y_annotation = [
+        "$0$",
+        "$f_{cd}$",
+        "$f_{ck}$",
+    ]
+
+    # add markers
+    plt.plot(x, y, "ok", ms=6)
+
+    # add tick labels for control points
+    plt.xticks(x, labels=x_annotation, fontsize=16)
+    plt.yticks(y_label, labels=y_annotation, fontsize=16)
+
+    # set min axes extent
+    xmin, xmax, ymin, ymax = plt.axis()
+    ax.axes.set_xlim(xmin)
+    ax.axes.set_ylim(ymin)
+
+    # add line to maximum strength f_cd at esp_c2
+    plt.plot(
+        [xmin, eps_c2, eps_c2],
+        [f_cd, f_cd, ymin],
+        "k",
+        linewidth=0.75,
+        dashes=[6, 6],
+    )
+
+    # add line to maximum strength f_ck at esp_c2
+    plt.plot(
+        [xmin, eps_c2, eps_c2],
+        [f_ck, f_ck, f_cd],
+        "k",
+        linewidth=0.75,
+        dashes=[6, 6],
+    )
+
+    # add line to maximum strength f_cd at esp_cu2
+    plt.plot(
+        [xmin, eps_cu2, eps_cu2],
+        [f_cd, f_cd, ymin],
+        "k",
+        linewidth=0.75,
+        dashes=[6, 6],
+    )
+
+    # add fill
+    plt.fill_between(
+        stress_strain_profile.strains,
+        stress_strain_profile.stresses,
+        0,
+        alpha=0.15,
+        color="grey",
+    )
+
+    # Turn off grid
+    plt.grid(False)
+
+    # turn off plot border
+    plt.box(False)
+
+    # turn on tight layout
+    plt.tight_layout()
+
+    # plot if required for testing purposes
+    if render:
+        plt.show()

--- a/docs/source/_static/doc_plots/mander_confined_plot.py
+++ b/docs/source/_static/doc_plots/mander_confined_plot.py
@@ -81,7 +81,7 @@ def mander_confined_plot(render=False):
     # add title and axes labels
     plt.title(label="Modified Mander Confined Stress-Strain Profile").set_fontsize(16)
     plt.xlabel("Compressive Strain $\\varepsilon_c$", labelpad=10).set_fontsize(16)
-    plt.ylabel("Compressive Strength $f_c$", labelpad=0).set_fontsize(16)
+    plt.ylabel("Compressive Strength $f_c$", labelpad=10).set_fontsize(16)
 
     # define data for annotations
     f_cc = max(stress_strain_profile.stresses)

--- a/docs/source/_static/doc_plots/mander_unconfined_plot.py
+++ b/docs/source/_static/doc_plots/mander_unconfined_plot.py
@@ -63,7 +63,7 @@ def mander_unconfined_plot(render=False):
     # add title and axes labels
     plt.title(label="Modified Mander Unconfined Stress-Strain Profile").set_fontsize(16)
     plt.xlabel("Compressive Strain $\\varepsilon_c$", labelpad=10).set_fontsize(16)
-    plt.ylabel("Compressive Strength $f_c$", labelpad=0).set_fontsize(16)
+    plt.ylabel("Compressive Strength $f_c$", labelpad=10).set_fontsize(16)
 
     # define data for annotations
     x = [

--- a/docs/source/notebooks/as3600.ipynb
+++ b/docs/source/notebooks/as3600.ipynb
@@ -334,10 +334,10 @@
     "\n",
     "# parabolic\n",
     "concrete.ultimate_stress_strain_profile = ssp.EurocodeParabolicUltimate(\n",
-    "    compressive_strength=0.9 * 40,\n",
-    "    compressive_strain=0.0015,\n",
-    "    ultimate_strain=0.003,\n",
-    "    n=2,\n",
+    "    compressive_strength=40,\n",
+    "    limiting_strain=0.003,\n",
+    "    alpha_cc=0.9,\n",
+    "    gamma_c=1,\n",
     ")\n",
     "f_mi_res_par, _, _ = design_code.moment_interaction_diagram(progress_bar=False)"
    ]
@@ -422,7 +422,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3 (ipykernel)",
+   "display_name": "Python 3",
    "language": "python",
    "name": "python3"
   },
@@ -436,11 +436,11 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.12"
+   "version": "3.10.9 (tags/v3.10.9:1dd9be6, Dec  6 2022, 20:01:21) [MSC v.1934 64 bit (AMD64)]"
   },
   "vscode": {
    "interpreter": {
-    "hash": "893b3ef6d13023afab4be8c5000be38ce11a760491bcfa4047435852657817d1"
+    "hash": "0803bda3a9df4dd3228c2723d1aeb0efd0f1b14533af55b8e50ccbc570bcf420"
    }
   }
  },

--- a/docs/source/user_guide/materials.rst
+++ b/docs/source/user_guide/materials.rst
@@ -343,11 +343,7 @@ Eurocode Parabolic Ultimate Profile
 
   EurocodeParabolicUltimate(
       compressive_strength=40,
-      compressive_strain=0.00175,
-      ultimate_strain=0.0035,
-      n=2,
   ).plot_stress_strain()
-
 
 
 Steel Stress-Strain Profiles


### PR DESCRIPTION
Hi @robbievanleeuwen 

Pull request addressing points noted in #79.

Note I decided at this stage against being able to specify the ultimate strain and transition strain as optional parameters pending your thoughts on the following. I think instead it is maybe better to add a further generic parabolic class (like you have for the Bilinear ssp) utilising the EC2 derivation for want of anything better, where you can specify these directly (basically almost like the older `EurocodeParabolicUltimate` class but renamed as a generic one? 

So you'd have the specific EC2 one with all the calculated factors, and then a generic one that takes a concrete strength that the user has already reduced to a design value as opposed to a characteristic value and a user-specified transition strain, ultimate strain and n_exp value.
(with this in mind potentially a warning is required in the generic ones to apply the equivalent of the `alpha` factor to reduce `concrete_strength` to a design value, this would be true of all the generic cases. Maybe the generic profiles should have another `alpha` factor reduction variable that is equal to 1.0 by default that the user can feed in a specific reduction factor if required by their use case).  

Note for the `AS3600` example changes, given I'm not too familiar with AS3600. Should the final design strength of the concrete be the `alpha` factor in `AS3600` class multiplied by the concrete strength multiplied by the 0.9 factor? 

So effectively you're comparing the stress-strain profile all with the same maximum design concrete strength? As it previously was arranged, this did not appear to be the case, bilinear and parabolic utilised `0.9*40` MPa, and the rectangular stress block utilised `alpha*0.9*40` which are not really consistent for comparing apples with apples which the plot is intended to do?

I'll do a similar approach for the EC2 bilinear class as for the parabolic class. I'll keep it draft until that is incorporated.

