### PR TITLE
Update AS3600.py to correctly calculate ku

### DIFF
--- a/src/concreteproperties/design_codes/as3600.py
+++ b/src/concreteproperties/design_codes/as3600.py
@@ -428,7 +428,7 @@ class AS3600(DesignCode):
                 m_xy=(decomp.m_xy + factor * (squash.m_xy - decomp.m_xy)) / phi,
             )
         # regular calculation
-        elif n_design > 0:
+        elif n_design >= 0:
             ult_res = self.concrete_section.ultimate_bending_capacity(
                 theta=theta, n=n_design / phi
             )


### PR DESCRIPTION
Resolves: Issue #104

Resolves the issue where ku in the AS3600 module was incorrectly outputted as zero in the instance when a concrete element was in pure bending (No applied axial load).

- [x] Run the **Nox** test suite to check for errors and warnings.

