### PR TITLE
feature: addresses #29 using vectorization instead of multiprocessing

### DIFF
--- a/tests/test_get_result_list.py
+++ b/tests/test_get_result_list.py
@@ -1,0 +1,124 @@
+import pytest
+import time
+import numpy as np
+from numpy import random, ndarray as NdArray, testing
+from dataclasses import dataclass, field
+from colorama import Fore, Style
+
+
+@dataclass(order=True)
+class UltimateBendingResults:
+    # bending angle
+    # theta: float
+
+    # ultimate neutral axis depth
+    # d_n: float = 0
+    # k_u: float = 0
+
+    # resultant actions
+    n: float = 0
+    m_x: float = 0
+    m_y: float = 0
+    m_xy: float = 0
+
+    # label
+    # label: str | None = field(default=None, compare=False)
+
+
+@dataclass
+class BiaxialBendingResults:
+    n: float
+    results: list[UltimateBendingResults] = field(default_factory=list)
+
+    def get_results_lists(self) -> tuple[list[float], list[float]]:
+        # build list of results
+        m_x_list = []
+        m_y_list = []
+
+        for result in self.results:
+            m_x_list.append(result.m_x)
+            m_y_list.append(result.m_y)
+
+        return m_x_list, m_y_list
+
+
+@dataclass
+class NewBiaxialBendingResults:
+    n: float
+    # results: list[UltimateBendingResults] = field(default_factory=list)
+    results: NdArray  # swap the list out for an NdArray
+
+    @classmethod
+    def from_list(
+        cls,
+        n: float,
+        results: list[UltimateBendingResults]
+        ):
+
+        dtype = [('m_x', float), ('m_y', float)]
+        # ... specifies the dtype for both m_x/y
+        
+        np_results: NdArray = np.array(
+            [
+            (result_.m_x, result_.m_y) 
+            for result_ in results
+            ], dtype=dtype )
+        
+        return cls(n, np_results)
+
+    def get_results_lists(self) -> tuple[np.ndarray, np.ndarray]:
+        return self.results['m_x'], self.results['m_y']
+
+
+def generate_test_data(num_results: int) -> list[UltimateBendingResults]:
+    return [UltimateBendingResults(
+        m_x=random.rand(), m_y=random.rand()
+        # examined operation is extracting the m_x/y from the results, only this is needed
+        ) for _ in range(num_results)]
+
+# --- ⏲️
+def time_execution(func, *args, **kwargs) -> tuple:
+    start_time = time.time()
+    result = func(*args, **kwargs)
+    end_time = time.time()
+
+    return (result, end_time - start_time)
+
+# --- 🧪
+@pytest.mark.parametrize("num_results", [10, 100, 1_000, 10_000, 100_000, 1_000_000])
+def test_get_results_lists(num_results) -> None:
+    random.seed(42)  # seed set for reproducible test outcome
+    
+    test_data: list[UltimateBendingResults] = generate_test_data(num_results)
+    
+    # --- Extract m_x/y from the same random test_data
+    original_results = BiaxialBendingResults(n=1_000, results=test_data) # same n_value for both, unlike inrweaxrion
+    new_results = NewBiaxialBendingResults.from_list(n=1_000, results=test_data)
+    
+    # --- Time the execution of both operations
+    (original_m_x, original_m_y), original_time = time_execution(original_results.get_results_lists) # Original
+    (new_m_x, new_m_y), new_time = time_execution(new_results.get_results_lists)  # New cl
+    
+    # --- Check correctness between operations
+    assert len(original_m_x) == len(new_m_x) == num_results  # check no. of results
+    assert len(original_m_y) == len(new_m_y) == num_results
+    
+    testing.assert_allclose(original_m_x, new_m_x) # check same values of m_x/y 
+    testing.assert_allclose(original_m_y, new_m_y)
+    
+    # --- Calc. speedup 
+    speedup = original_time / new_time if new_time > 0 else float('inf')
+    assert new_time < original_time # 
+
+    # --- 📝 Compare
+    print(f"\nFor {num_results:,} results:")
+    
+    # print(f"🐌 Original method: {original_time:.6f} seconds")
+    # print(f"🐎 New method: {new_time:.6f} seconds")
+    print(f"🐌 Original method: {original_time:.3e} seconds]")
+    print(f"🐎 New method: {new_time:.3e} secons]")
+    print(f"⚡ SPEEDUP: {speedup:.2f}x")
+
+if __name__ == "__main__":
+    pytest.main([__file__])
+    test_get_results_lists(num_results=555_555)


### PR DESCRIPTION
From #29 :
**TLDR**: `multprocessing` might be overkill for this task. Vectorisation using `numpy` arrays works. I've swapped the lists for `ndarray` where possible and it's worked. Run the test using `pytest` to show the results are the same and the new `BiaxialBendingResults.get_results_list()` is faster.

---
## Why `multiprocessing` might not work
I feel the need to explain this because my solution veers away from your original idea of parallelising the operation.
I've worked quite a bit with async in web servers so I have a good idea of how multiprocessing works, including in Python. Compared to the database operations and handling http requests, accessing the contents of a list are quite small. So small that spreading out the processes using a pool might make the operation run even slower than it already is.

## Vectorisation with `numpy` arrays
Vector operations will give you that sense of "parallel computing" without the overhead of spreading the tasks over CPU cores. The simplest way to do this is with numpy arrays, i.e changing from this

```python
for result in self.results:
    m_x_list.append(result.
    m_y_list.append(result.m_y)
```
to this 

```python
np_results: NdArray = np.array(
    [ (m_x, result_.m_y) for result_ in results ], dtype=dtype )
```

works well enough because:
1. NumPy is already significantly faster than pure python and;
2. this kind of operation (creating a sequence) is limited more by RAM, not by CPU.

Here's a [github gist](<script src="https://gist.github.com/waynemaranga/96aa073984a8394a4c4f2906ad93c8b0.js"></script>)of the tests I ran with random results data between 1 result and 1,000,000. The benchmark is well into the 10,000x speed up for thousands of results.

![image](https://github.com/user-attachments/assets/9f2171b0-4488-4005-bde8-a24c7bf0cc6f)

There's a link to the Colab Notebook so you can run the test yourself.
I am in the process of doing something similar for `MomentInteractionResults.get_results_list()`. Now, I _would_ have added the implementations of `multiprocessing` that I tried out but I felt it unnecessary given the explanations above, but you're welcome to ask for them. I like this library very much btw.
      ]

<!-- This is just a reminder about the most common mistakes. Please make sure that you
tick all *appropriate* boxes.  But please read our
[contribution guide](https://github.com/robbievanleeuwen/concrete-properties/blob/master/CONTRIBUTING.md)
at least once, it will save you unnecessary review cycles! -->

- [x] Added **tests** for changed code. _The code itself is in_ `tests`
- [ ] Updated **documentation** for changed code. _Not sure if I should do this when writing a test. More like a draft_
- [x] Run the **Nox** test suite to check for errors and warnings. _All Passing_

<!-- If you have *any* questions to *any* of the points above, just **submit and ask**!
This checklist is here to *help* you, not to deter you from contributing! -->
