### PR TITLE
Fix NZ code density units

### DIFF
--- a/docs/examples/nzs3101.ipynb
+++ b/docs/examples/nzs3101.ipynb
@@ -105,7 +105,7 @@
    "outputs": [],
    "source": [
     "print(steel_300e.name)\n",
-    "print(f\"Density = {steel_300e.density} kg/m^3\")\n",
+    "print(f\"Density = {steel_300e.density} kg/mm^3\")\n",
     "ult_strain = steel_300e.stress_strain_profile.get_ultimate_tensile_strain()\n",
     "print(f\"Ultimate Tensile Strain = {ult_strain}\")\n",
     "print(f\"Overstrength Factor = {steel_300e.phi_os}\")\n",
@@ -695,7 +695,7 @@
     "# moment-curvature analysis\n",
     "concrete_25_prob = Concrete(\n",
     "    name=\"Mander Concrete\",\n",
-    "    density=2300,\n",
+    "    density=2.3e-6,\n",
     "    stress_strain_profile=ModifiedMander(\n",
     "        elastic_modulus=design_code.e_conc(prob_compressive_strength),\n",
     "        compressive_strength=prob_compressive_strength,\n",
@@ -737,7 +737,7 @@
    "outputs": [],
    "source": [
     "print(steel_275.name)\n",
-    "print(f\"Density = {steel_275.density} kg/m^3\")\n",
+    "print(f\"Density = {steel_275.density} kg/mm^3\")\n",
     "print(\n",
     "    f\"Probable yield strength = {steel_275.stress_strain_profile.get_yield_strength()}\"\n",
     "    f\" MPa\"\n",

--- a/docs/user_guide/design_codes/nzs3101.rst
+++ b/docs/user_guide/design_codes/nzs3101.rst
@@ -21,10 +21,15 @@ created it must be assigned to the design code::
 ..  automethod:: concreteproperties.design_codes.nzs3101.NZS3101.assign_concrete_section
   :noindex:
 
-.. note::
+.. warning::
 
-  To maintain unit consistency, the cross-section dimensions should be entered in
-  *[mm]*.
+  To maintain unit consistency, length dimensions must be entered in *[mm]*, force
+  dimensions entered in *[N]* and density dimensions entered |dunits|, unless otherwise
+  specified in the documentation.
+
+.. |dunits| raw:: html
+
+  <em>[kg/mm<sup>3</sup>]</em>
 
 
 Creating Material Properties

--- a/src/concreteproperties/design_codes/as3600.py
+++ b/src/concreteproperties/design_codes/as3600.py
@@ -163,7 +163,7 @@ class AS3600(DesignCode):
 
         .. admonition:: Material assumptions
 
-          - *Density*: 7850 kg/m\ :sup:`3`
+          - *Density*: 7850 kg/m\ :sup:`3` (7.85 x 10\ :sup:`-6` kg/mm\ :sup:`3`)
 
           - *Elastic modulus*: 200000 MPa
 

--- a/src/concreteproperties/design_codes/nzs3101.py
+++ b/src/concreteproperties/design_codes/nzs3101.py
@@ -841,7 +841,8 @@ class NZS3101(DesignCode):
 
         .. admonition:: Material assumptions
 
-          - *Density*: Defaults to 2300 kg/m\ :sup:`3` unless supplied as user input
+          - *Density*: Defaults to 2300 kg/m\ :sup:`3`
+            (2.3 x 10\ :sup:`-6` kg/mm\ :sup:`3`), unless supplied as user input
 
           - *Elastic modulus*: Calculated from NZS3101:2006 Eq. 5-1
 
@@ -883,7 +884,7 @@ class NZS3101(DesignCode):
 
         return Concrete(
             name=name,
-            density=density,
+            density=density / 1e9,
             stress_strain_profile=ssp.ConcreteLinearNoTension(
                 elastic_modulus=elastic_modulus,
                 ultimate_strain=ultimate_strain,
@@ -984,7 +985,7 @@ class NZS3101(DesignCode):
 
         .. admonition:: Material assumptions
 
-          - *Density*: 7850 kg/m\ :sup:`3`
+          - *Density*: 7850 kg/m\ :sup:`3` (7.85 x 10\ :sup:`-6` kg/mm\ :sup:`3`)
 
           - *Elastic modulus*: 200000 MPa
 
@@ -1043,13 +1044,13 @@ class NZS3101(DesignCode):
             **NZS3101:2006 characteristic yield strength based predefined
             materials:**
 
-            - ``""300e""`` - Use for design to NZS3101:2006 provisions
+            - ``"300e"`` - Use for design to NZS3101:2006 provisions
 
               - Characteristic yield strength :math:`f_y` = 300 MPa
               - Fracture strain :math:`\varepsilon_{su}` = 15% or 0.15
               - Overstrength factor :math:`\phi_{o,f_y}` = 1.35
 
-            - ``""500e""`` - Use for design to NZS3101:2006 provisions
+            - ``"500e"`` - Use for design to NZS3101:2006 provisions
 
               - Characteristic yield strength :math:`f_y` = 500 MPa
               - Fracture strain :math:`\varepsilon_{su}` = 10% or 0.10
@@ -1058,84 +1059,84 @@ class NZS3101(DesignCode):
             **NZSEE C5 guidelines probable yield strength based predefined
             materials:**
 
-            - ``""pre_1945""``- Use for probable strength design to NZSEE C5
+            - ``"pre_1945"``- Use for probable strength design to NZSEE C5
               assessment guidelines
 
               - Probable yield strength :math:`f_{yp}` = 280 MPa
               - Fracture strain :math:`\varepsilon_{su}` = 10% or 0.10
               - Overstrength factor :math:`\phi_{f_o}` = 1.25
 
-            - ``""33""`` - Use for probable strength design to NZSEE C5 assessment
+            - ``"33"`` - Use for probable strength design to NZSEE C5 assessment
               guidelines
 
               - Probable yield strength :math:`f_{yp}` = 280 MPa
               - Fracture strain :math:`\varepsilon_{su}` = 10% or 0.10
               - Overstrength factor :math:`\phi_{f_o}` = 1.25
 
-            - ``""40""`` - Use for probable strength design to NZSEE C5 assessment
+            - ``"40"`` - Use for probable strength design to NZSEE C5 assessment
               guidelines
 
               - Probable yield strength :math:`f_{yp}` = 324 MPa
               - Fracture strain :math:`\varepsilon_{su}` = 15% or 0.15
               - Overstrength factor :math:`\phi_{f_o}` = 1.25
 
-            - ``""275""`` - Use for probable strength design to NZSEE C5 assessment
+            - ``"275"`` - Use for probable strength design to NZSEE C5 assessment
               guidelines
 
               - Probable yield strength :math:`f_{yp}` = 324 MPa
               - Fracture strain :math:`\varepsilon_{su}` = 15% or 0.15
               - Overstrength factor :math:`\phi_{f_o}` = 1.25
 
-            - ``""hy60""`` - Use for probable strength design to NZSEE C5 assessment
+            - ``"hy60"`` - Use for probable strength design to NZSEE C5 assessment
               guidelines
 
               - Probable yield strength :math:`f_{yp}` = 455 MPa
               - Fracture strain :math:`\varepsilon_{su}` = 12% or 0.12
               - Overstrength factor :math:`\phi_{f_o}` = 1.5
 
-            - ``""380""`` - Use for probable strength design to NZSEE C5 assessment
+            - ``"380"`` - Use for probable strength design to NZSEE C5 assessment
               guidelines
 
               - Probable yield strength :math:`f_{yp}` = 455 MPa
               - Fracture strain :math:`\varepsilon_{su}` = 12% or 0.12
               - Overstrength factor :math:`\phi_{f_o}` = 1.5
 
-            - ``""430""`` - Use for probable strength design to NZSEE C5 assessment
+            - ``"430"`` - Use for probable strength design to NZSEE C5 assessment
               guidelines
 
               - Probable yield strength :math:`f_{yp}` = 464 MPa
               - Fracture strain :math:`\varepsilon_{su}` = 12% or 0.12
               - Overstrength factor :math:`\phi_{f_o}` = 1.25
 
-            - ``""300""`` - Use for probable strength design to NZSEE C5 assessment
+            - ``"300"`` - Use for probable strength design to NZSEE C5 assessment
               guidelines
 
               - Probable yield strength :math:`f_{yp}` = 324 MPa
               - Fracture strain :math:`\varepsilon_{su}` = 15% or 0.15
               - Overstrength factor :math:`\phi_{f_o}` = 1.25
 
-            - ``""500n""`` - Use for probable strength design to NZSEE C5 assessment
+            - ``"500n"`` - Use for probable strength design to NZSEE C5 assessment
               guidelines
 
               - Probable yield strength :math:`f_{yp}` = 500 MPa
               - Fracture strain :math:`\varepsilon_{su}` = 5% or 0.05
               - Overstrength factor :math:`\phi_{f_o}` = 1.5
 
-            - ``""500""`` - Use for probable strength design to NZSEE C5 assessment
+            - ``"500"`` - Use for probable strength design to NZSEE C5 assessment
               guidelines
 
               - Probable yield strength :math:`f_{yp}` = 540 MPa
               - Fracture strain :math:`\varepsilon_{su}` = 10% or 0.10
               - Overstrength factor :math:`\phi_{f_o}` = 1.25
 
-            - ``""cd_mesh""`` - Use for probable strength design to NZSEE C5
+            - ``"cd_mesh"`` - Use for probable strength design to NZSEE C5
               assessment guidelines
 
               - Probable yield strength :math:`f_{yp}` = 600 MPa
               - Fracture strain :math:`\varepsilon_{su}` = 1.5% or 0.015
               - Overstrength factor :math:`\phi_{f_o}` = 1.2
 
-            - ``""duc_mesh""`` - Use for probable strength design to NZSEE C5
+            - ``"duc_mesh"`` - Use for probable strength design to NZSEE C5
               assessment guidelines
 
               - Probable yield strength :math:`f_{yp}` = 500 MPa
@@ -1197,7 +1198,7 @@ class NZS3101(DesignCode):
         return NZS3101.SteelBarNZ(
             name=name,
             steel_grade=steel_grade,
-            density=density,
+            density=density / 1e9,
             phi_os=phi_os,
             stress_strain_profile=ssp.SteelElasticPlastic(
                 yield_strength=yield_strength,
@@ -1463,7 +1464,7 @@ class NZS3101(DesignCode):
                 compressive_strength=prev_compressive_strength
                 + add_compressive_strength,
                 ultimate_strain=prev_ultimate_strain,
-                density=prev_density,
+                density=prev_density * 1e9,
                 colour=prev_colour_conc,
             )
 
@@ -1557,7 +1558,7 @@ class NZS3101(DesignCode):
             conc_geom.material = self.create_concrete_material(
                 compressive_strength=prob_compressive_strength,
                 ultimate_strain=prev_ultimate_strain,
-                density=prev_density,
+                density=prev_density * 1e9,
                 colour=prev_colour_conc,
             )
 

--- a/tests/test_nzs3101.py
+++ b/tests/test_nzs3101.py
@@ -477,7 +477,7 @@ def test_nzs3101_create_steel_material_meshed_valueerror():
     # create concrete material
     concrete = Concrete(
         name="50 MPa Concrete",
-        density=2300,
+        density=2.3e-6,
         stress_strain_profile=ssp.ConcreteLinearNoTension(
             elastic_modulus=design_code.e_conc(50),
             ultimate_strain=0.003,
@@ -496,7 +496,7 @@ def test_nzs3101_create_steel_material_meshed_valueerror():
     # create meshed steel material
     steel = Steel(
         name="Meshed Steel",
-        density=7850,
+        density=7.85e-6,
         stress_strain_profile=ssp.SteelElasticPlastic(
             yield_strength=300,
             elastic_modulus=200e3,
@@ -589,7 +589,7 @@ def test_nzs3101_create_concrete_material(
     concrete_mat = design_code.create_concrete_material(
         compressive_strength, ultimate_strain, density
     )
-    assert pytest.approx(concrete_mat.__getattribute__("density")) == density
+    assert pytest.approx(concrete_mat.__getattribute__("density")) == density * 1e-9
     assert (
         pytest.approx(
             concrete_mat.__getattribute__("flexural_tensile_strength"), rel=0.001
@@ -707,7 +707,7 @@ def test_nzs3101_create_os_section(
         conc_geom.material.ultimate_stress_strain_profile.__setattr__(
             "ultimate_strain", ultimate_strain
         )
-        conc_geom.material.__setattr__("density", density)
+        conc_geom.material.__setattr__("density", density * 1e-9)
 
     concrete_os_section = design_code.create_os_section()
     # check steel overstrength properties
@@ -736,7 +736,10 @@ def test_nzs3101_create_os_section(
 
     # check concrete overstrength properties
     for conc_geom in concrete_os_section.concrete_geometries:
-        assert pytest.approx(conc_geom.material.__getattribute__("density")) == density
+        assert (
+            pytest.approx(conc_geom.material.__getattribute__("density"))
+            == density * 1e-9
+        )
         assert (
             pytest.approx(
                 conc_geom.material.__getattribute__("flexural_tensile_strength"),
@@ -863,7 +866,7 @@ def test_nzs3101_create_prob_section(
         conc_geom.material.ultimate_stress_strain_profile.__setattr__(
             "ultimate_strain", ultimate_strain
         )
-        conc_geom.material.__setattr__("density", 2300)
+        conc_geom.material.__setattr__("density", 2.3e-6)
 
     concrete_prob_section = design_code.create_prob_section()
     # check steel overstrength properties
@@ -1012,7 +1015,7 @@ def test_nzs3101_create_prob_os_section(
         conc_geom.material.ultimate_stress_strain_profile.__setattr__(
             "ultimate_strain", ultimate_strain
         )
-        conc_geom.material.__setattr__("density", 2300)
+        conc_geom.material.__setattr__("density", 2.3e-6)
 
     concrete_prob_section = design_code.create_prob_section(os_design=True)
     # check steel overstrength properties
@@ -1463,7 +1466,7 @@ def test_nzs3101_create_section_with_non_steelbarnz_material():
     # create concrete material
     concrete = Concrete(
         name="50 MPa Concrete",
-        density=2300,
+        density=2.3e-6,
         stress_strain_profile=ssp.ConcreteLinearNoTension(
             elastic_modulus=design_code.e_conc(50),
             ultimate_strain=0.003,
@@ -1482,7 +1485,7 @@ def test_nzs3101_create_section_with_non_steelbarnz_material():
     # create non SteelBarNZ steel material
     steel = SteelBar(
         name="Meshed Steel",
-        density=7850,
+        density=7.85e-6,
         stress_strain_profile=ssp.SteelElasticPlastic(
             yield_strength=300,
             elastic_modulus=200e3,


### PR DESCRIPTION
Closes #146.

Addresses density being stored inconsistently in the NZ code material objects as `kg/m^3` rather than the consistent `kg/mm^3`. Only the mass per unit length was affected.